### PR TITLE
Fix row selection refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,15 +197,17 @@
                 a.href = msg.webUrl;
                 a.target = "_blank";
                 a.textContent = "Переглянути";
-                a.addEventListener("click", async () => {
+                row.appendChild(createCell(a));
+
+                row.addEventListener("click", async () => {
                   if (selectedRow && selectedRow !== row) {
                     await refreshRow(selectedRow);
                     selectedRow.classList.remove("selected");
                   }
                   row.classList.add("selected");
                   selectedRow = row;
+                  await refreshRow(row);
                 });
-                row.appendChild(createCell(a));
 
                 row.appendChild(createCell(createReplyList(replies)));
                 row.appendChild(createCell(extractLastTextBlock(msg.attachments?.[0]?.content), "wrap-text"));


### PR DESCRIPTION
## Summary
- highlight selected table row on click anywhere
- reload row data when it becomes selected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68429b8e0538832c875c89a8de654cfb