### PR TITLE
Fix refreshRow appendChild bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,12 @@
         return;
       }
       row.cells[2].innerHTML = "";
-      row.cells[2].appendChild(createReplyList(data.replies || []));
+      const repliesContent = createReplyList(data.replies || []);
+      if (repliesContent instanceof Node) {
+        row.cells[2].appendChild(repliesContent);
+      } else {
+        row.cells[2].textContent = repliesContent;
+      }
       row.cells[3].textContent = extractLastTextBlock(data.attachments?.[0]?.content);
     }
     function createCell(content, className) {


### PR DESCRIPTION
## Summary
- handle non-Node return from `createReplyList` in `refreshRow`

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68429ed7d994832cbfb63a8c3cc9813e