### PR TITLE
Remove Teams fallback prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,12 +202,6 @@
       const deepLink = getTeamsDeepLink(webUrl);
       if (!deepLink) return;
       window.location.href = deepLink;
-      setTimeout(() => {
-        if (!document.hidden) {
-          const openWeb = confirm("Не вдалося відкрити Teams. Відкрити у браузері?");
-          if (openWeb) window.open(webUrl, "_blank");
-        }
-      }, 1500);
     }
 
     async function loadMessages() {


### PR DESCRIPTION
## Summary
- remove user-facing prompt about failing to open Teams

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842c6dddc54832c95238e130656a61f